### PR TITLE
Add include path to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "UNL/PHPDWTParser",
     "autoload": {
         "psr-0": { "": "src/" }
-    }
+    },
     "include-path": ["src"]
 }
 


### PR DESCRIPTION
This library used an older style of including other classes and files (not autoloading), using `include_once` and `require_once`.

The easiest way to fix this is to use composer's `include-path`, which is sadly deprecated.  Long story short, this is a band-aid and the library should probably be updated to take advantage of autoloading.
